### PR TITLE
Adding missing dependencies to the pom file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,5 +51,26 @@
             <artifactId>aliyun-java-sdk-slb</artifactId>
             <version>2.0.0-rc1</version>
         </dependency>
+        <dependency>
+            <groupId>com.github.jpbc-api</groupId>
+            <artifactId>jpbc-api</artifactId>
+            <version>2.0.0</version>
+            <scope>system</scope>
+            <systemPath>${project.basedir}/libs/jpbc-api-2.0.0.jar</systemPath>
+        </dependency>
+        <dependency>
+            <groupId>com.github.jpbc-crypto</groupId>
+            <artifactId>jpbc-crypto</artifactId>
+            <version>2.0.0</version>
+            <scope>system</scope>
+            <systemPath>${project.basedir}/libs/jpbc-crypto-2.0.0.jar</systemPath>
+        </dependency>
+        <dependency>
+            <groupId>com.github.jpbc-plaf</groupId>
+            <artifactId>jpbc-plaf</artifactId>
+            <version>2.0.0</version>
+            <scope>system</scope>
+            <systemPath>${project.basedir}/libs/jpbc-plaf-2.0.0.jar</systemPath>
+        </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
This pull request addresses missing dependencies in the pom.xml file by adding necessary libraries from the JPBC library. I got errors when running the tests with maven ("mvn clean package") but with these changes i dont have those problems anymore.

# Changes Made
Added three dependencies from the JPBC library to the pom.xml:
- jpbc-api
- jpbc-crypto
- jpbc-plaf

The libraries are referenced with a system scope, and their paths are specified relative to the project base directory (${project.basedir}/libs/).

Now when i try "mvn clean package" i can run all the tests.